### PR TITLE
build: bump min node version to 10.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 11.x, 12.x]
+        node-version: [10.x, 12.x, 13.x, 14.x]
     name: node.js ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Node 8.x is no longer maintained.